### PR TITLE
Setting riker version to 1.1.0 because it's a known working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "osenv": "^0.1.3",
     "probo-eventbus": "^0.2.0",
     "request": "^2.74.0",
-    "riker": "^1.1.0",
+    "riker": "1.1.0",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
There has been continuing work on riker but the notifier has not kept up.  This pr sets riker to a known working version.